### PR TITLE
Rename Revit demo ACC references to Autodesk Forma naming

### DIFF
--- a/src/Revit/dotnet/RevitExtensionDemo/Forma/FormaClient.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/Forma/FormaClient.cs
@@ -1,15 +1,15 @@
-using RevitExtensionDemo.ACC.Responses.GetAllHubs;
-using RevitExtensionDemo.ACC.Responses.GetAllProjects;
-using RevitExtensionDemo.ACC.Responses.GetFolderContent;
-using RevitExtensionDemo.ACC.Responses.GetTopFolders;
+using RevitExtensionDemo.Forma.Responses.GetAllHubs;
+using RevitExtensionDemo.Forma.Responses.GetAllProjects;
+using RevitExtensionDemo.Forma.Responses.GetFolderContent;
+using RevitExtensionDemo.Forma.Responses.GetTopFolders;
 
-namespace RevitExtensionDemo.ACC;
+namespace RevitExtensionDemo.Forma;
 
-public class AccClient
+public class FormaClient
 {
     private readonly IExtensionHttpClient _client;
 
-    public AccClient(IExtensionHttpClient client)
+    public FormaClient(IExtensionHttpClient client)
     {
         _client = client;
     }

--- a/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetAllHubs/Responses.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetAllHubs/Responses.cs
@@ -1,4 +1,4 @@
-namespace RevitExtensionDemo.ACC.Responses.GetAllHubs;
+namespace RevitExtensionDemo.Forma.Responses.GetAllHubs;
 // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
 public class Attributes
 {

--- a/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetAllProjects/Responses.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetAllProjects/Responses.cs
@@ -1,4 +1,4 @@
-namespace RevitExtensionDemo.ACC.Responses.GetAllProjects;
+namespace RevitExtensionDemo.Forma.Responses.GetAllProjects;
 // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
     public class Attributes
     {
@@ -146,5 +146,4 @@ namespace RevitExtensionDemo.ACC.Responses.GetAllProjects;
     {
         public string Href { get; set; }
     }
-
 

--- a/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetFolderContent/Responses.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetFolderContent/Responses.cs
@@ -1,4 +1,4 @@
-namespace RevitExtensionDemo.ACC.Responses.GetFolderContent;
+namespace RevitExtensionDemo.Forma.Responses.GetFolderContent;
 // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
 // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
 public class Attributes

--- a/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetTopFolders/Responses.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/Forma/Responses/GetTopFolders/Responses.cs
@@ -1,4 +1,4 @@
-namespace RevitExtensionDemo.ACC.Responses.GetTopFolders;
+namespace RevitExtensionDemo.Forma.Responses.GetTopFolders;
 
 public class Attributes
 {
@@ -110,4 +110,3 @@ public class WebView
 {
     public string Href { get; set; }
 }
-

--- a/src/Revit/dotnet/RevitExtensionDemo/RevitExtensionDemoCommand.cs
+++ b/src/Revit/dotnet/RevitExtensionDemo/RevitExtensionDemoCommand.cs
@@ -1,4 +1,4 @@
-﻿using RevitExtensionDemo.ACC;
+﻿using RevitExtensionDemo.Forma;
 
 namespace RevitExtensionDemo;
 
@@ -25,7 +25,7 @@ public class RevitExtensionDemoCommand : IRevitExtension<RevitExtensionDemoArgs>
             return Result.Text.Failed("No ValueCopy configuration provided.");
         }
 
-        var client = new AccClient(args.AutodeskClient);
+        var client = new FormaClient(args.AutodeskClient);
         var hubs = client.GetHubs();
         message += $"Found {hubs.Data.Count} hubs.\n";
         var hub = hubs.Data.First(x => x.Attributes.Extension.Type == "hubs:autodesk.bim360:Account");


### PR DESCRIPTION
## Summary
- Renamed the Revit demo ACC client area from `ACC` to `Forma`
- Updated namespaces from `RevitExtensionDemo.ACC.*` to `RevitExtensionDemo.Forma.*`
- Renamed `AccClient` to `FormaClient` and updated command usage

## Verification checklist
- [x] Repository search shows no remaining `ACC` or `Autodesk Construction Cloud` references
- [x] `dotnet build src/Revit/dotnet/RevitExtensionDemo/RevitExtensionDemo.sln -nologo`

## Release note
Renamed ACC branding references in the Revit demo extension to Autodesk Forma naming (`ACC` -> `Forma`). No functional API behavior changes were introduced.

## Compatibility / link impact
- This change updates internal code organization (folder, class, and namespace names) in the demo extension only.
- No external docs/wiki links were changed because no ACC-branded docs/wiki references were found in this repository.